### PR TITLE
Add generate.tasks demo for appending to existing ubuntu2004 variant

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -32,6 +32,8 @@ buildvariants:
     expansions:
       module_prefix: hello
     tasks:
+      # generate.tasks JSON only references existing variant ubuntu2004 and adds tasks under it.
+      - name: append_existing_bv_generate
       - name: task_generator
       - name: unit_tests
       - name: validate_commit_message
@@ -269,6 +271,12 @@ tasks:
         params:
           files:
             - src/generate.json
+  - name: append_existing_bv_generate
+    commands:
+      - command: generate.tasks
+        params:
+          files:
+            - src/generate_append_existing_bv.json
   - name: test_release
     depends_on:
       - name: unit_tests

--- a/src/generate.json
+++ b/src/generate.json
@@ -1,0 +1,25 @@
+{
+  "buildvariants": [
+    {
+      "name": "ubuntu2004",
+      "tasks": [
+        {
+          "name": "task-to-add-via-generator"
+        }
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "name": "task-to-add-via-generator",
+      "commands": [
+        {
+          "command": "shell.exec",
+          "params": {
+            "script": "echo generated_task"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/generate_append_existing_bv.json
+++ b/src/generate_append_existing_bv.json
@@ -1,0 +1,30 @@
+{
+  "buildvariants": [
+    {
+      "name": "ubuntu2004",
+      "tasks": [
+        {
+          "name": "dynamic_task_appended_to_existing_bv",
+          "depends_on": [
+            {
+              "name": "append_existing_bv_generate"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "name": "dynamic_task_appended_to_existing_bv",
+      "commands": [
+        {
+          "command": "shell.exec",
+          "params": {
+            "script": "echo 'This task was merged into the pre-existing ubuntu2004 variant (append-to-existing-BV demo).'"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a small Evergreen config demo for **generate.tasks** that only references the **existing** `ubuntu2004` build variant (merge/append style), plus fixes the generator file path.

## Changes
- **`src/generate.json`** — used by existing `task_generator`; adds `task-to-add-via-generator` under `ubuntu2004` (the path `src/generate.json` previously had no file in-repo).
- **`append_existing_bv_generate`** — new task that runs `generate.tasks` with `src/generate_append_existing_bv.json`, which adds `dynamic_task_appended_to_existing_bv` under the same variant with a `depends_on` the generator task.
- **`ubuntu2004`** — schedules `append_existing_bv_generate` before `task_generator`.

## How to try
Run `append_existing_bv_generate` (or `task_generator`) on `ubuntu2004` and confirm the dynamically added task(s) appear on that variant after generation completes.


Made with [Cursor](https://cursor.com)